### PR TITLE
Fix README heading typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Getting Started
 
-### Prerequesites
+### Prerequisites
 - [rust](https://www.rust-lang.org/) installed
 
 ### Run the Hub


### PR DESCRIPTION
## Summary
- correct `### Prerequesites` typo to `### Prerequisites`

## Testing
- `grep -Rin "Prerequesites" .`

------
https://chatgpt.com/codex/tasks/task_e_683f43a2a998832db05ea9102e956d94