### PR TITLE
Fix cleanup comment

### DIFF
--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -23,7 +23,7 @@ pub async fn run(running: Arc<AtomicBool>) {
             }
         }
 
-        // Insert CPU usage into the database
+        // Expire old CPU usage records
         if let Err(e) = expire_records() {
             eprintln!("Error expiring records: {e}");
         }


### PR DESCRIPTION
## Summary
- clarify the cleanup comment about expiring old CPU usage records

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_683f473e86a4832db87e81c8df4fd394